### PR TITLE
Convert instructors and materials page sidebar from bootstrap to material design

### DIFF
--- a/instructor.html
+++ b/instructor.html
@@ -5,375 +5,145 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="author" content="DSC FUTA" />
-    <meta
-      name="description"
-      content="Developer Student Clubs (DSC)a is a Google Developers program for university students to learn mobile and web development skills."
-    />
-    <meta
-      name="keywords"
-      content="dsc, futa, kelvin kamau,google developers, sub saharan africa, kenya, computer science"
-    />
+    <meta name="description" content="Developer Student Clubs (DSC)a is a Google Developers program for university students to learn mobile and web development skills."/>
+    <meta name="keywords" content="dsc, futa, kelvin kamau,google developers, sub saharan africa, kenya, computer science"/>
     <title>DSC Admin - Instructors</title>
     <link rel="icon" href="images/icon.png" type="image/png" />
+    <!-- Temporarily left here because of the main content -->
     <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet" />
-    <link
-      href="vendor/fontawesome-free/css/all.min.css"
-      rel="stylesheet"
-      type="text/css"
-    />
-    <link
-      href="vendor/datatables/dataTables.bootstrap4.min.css"
-      rel="stylesheet"
-    />
-    <link href="css/admin.css" rel="stylesheet" />
+    <link href="vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css"/>
+    <link href="vendor/datatables/dataTables.bootstrap4.min.css" rel="stylesheet"/>
+    <link href="css/admin.css" rel="stylesheet" /> 
+    <!-- the above are Temporarily left here because of the main content -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+    <link rel="stylesheet" href="css/styles.css">
   </head>
 
-  <body id="page-top">
-    <nav class="navbar navbar-expand navbar-dark bg-dark static-top">
-      <a class="navbar-brand mr-1" href="index.html"
-        ><img href="images/icon.png" />DSC Admin</a
-      >
-
-      <button
-        class="btn btn-link btn-sm text-white order-1 order-sm-0"
-        id="sidebarToggle"
-        href="#"
-      >
-        <i class="fas fa-bars"></i>
-      </button>
-
-      <!-- Navbar Search -->
-      <form
-        class="d-none d-md-inline-block form-inline ml-auto mr-0 mr-md-3 my-2 my-md-0"
-      >
-        <div class="input-group">
-          <input
-            type="text"
-            class="form-control"
-            placeholder=" "
-            aria-label="Search"
-            aria-describedby="basic-addon2"
-          />
-          <div class="input-group-append">
-            <button class="btn btn-primary" type="button">
-              <i class="fas fa-search"></i>
-            </button>
-          </div>
-        </div>
-      </form>
-
-      <!-- Navbar -->
-      <ul class="navbar-nav ml-auto ml-md-0">
-        <li class="nav-item dropdown no-arrow">
-          <a
-            class="nav-link dropdown-toggle"
-            href="#"
-            id="userDropdown"
-            role="button"
-            data-toggle="dropdown"
-            aria-haspopup="true"
-            aria-expanded="false"
-          >
-            <i class="fas fa-user-circle fa-fw"></i>
-          </a>
-          <div
-            class="dropdown-menu dropdown-menu-right"
-            aria-labelledby="userDropdown"
-          >
-            <a
-              class="dropdown-item"
-              href="#"
-              data-toggle="modal"
-              data-target="#logoutModal"
-              >Logout</a
-            >
-            <a class="dropdown-item" href="index.html">Back to homepage</a>
-          </div>
-        </li>
-      </ul>
-    </nav>
+  <body class="mdc-typography">
+    <header class="mdc-top-app-bar mdc-top-app-bar--fixed" data-mdc-auto-init="MDCTopAppBar">
+      <div class="mdc-top-app-bar__row">
+        <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
+          <a href="index" class="material-icons mdc-top-app-bar__navigation-icon">home</a>
+          <span class="mdc-top-app-bar__title">Instructors</span>
+        </section>
+        <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
+          <a href="#" id="logoutButton" class="material-icons mdc-top-app-bar__action-item" aria-label="Logout"
+            alt="Logout">exit_to_app</a>
+        </section>
+      </div>
+    </header>
 
     <div id="wrapper">
-      <!-- Sidebar -->
-      <ul class="sidebar navbar-nav">
-        <li class="nav-item">
-          <a class="nav-link" href="index.html">
-            <i class="fas fa-fw fa-tachometer-alt"></i> <span>Dashboard</span>
-          </a>
-        </li>
-        <li class="nav-item active">
-          <a class="nav-link" href="instructor.html">
-            <i class="fas fa-fw fa-user-alt"></i> <span>Instructor</span>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="events.html">
-            <i class="fas fa-fw fa-calendar-alt"></i> <span>Events</span>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="projects.html">
-            <i class="fas fa-fw fa-folder"></i> <span>Projects</span>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="tutorials.html">
-            <i class="fas fa-fw fa-book"></i> <span>Tutorials</span>
-          </a>
-        </li>
-      </ul>
-
-      <div id="content-wrapper">
-        <div class="container-fluid">
-          <!-- Breadcrumbs-->
-          <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="#">Dashboard</a></li>
-            <li class="breadcrumb-item active">Instructors</li>
-          </ol>
-
-          <!-- dashboard card -->
-          <div class="card mb-3">
-            <div class="card-header">
-              <i class="fas fa-fw fa-user"></i> Instructor
-              <i class="fas fa-sync fa-spin" id="refreshButton"></i>
-            </div>
-            <div class="card-body">
-              <div
-                class="alert alert-danger"
-                id="instructorErrorAlert"
-                style="display: none"
-              ></div>
-              <table
-                class="table table-striped"
-                id="instructorsTable"
-                style="min-width: 100%"
-              >
-                <thead>
-                  <tr>
-                    <th>Instructor's Name</th>
-                    <th>Instructor's Bio</th>
-                    <th>Instructor's Role</th>
-                    <th>Instructor's TwitterId</th>
-                    <th>Instructor's GithubId</th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
-                <tbody></tbody>
-              </table>
-            </div>
-            <div class="card-footer text-right">
-              <button class="btn btn-primary" id="addButton" disabled>
-                Add Instructor
-              </button>
-            </div>
+      <div class="mdc-top-app-bar--fixed-adjust">
+        <aside class="mdc-drawer">
+          <div class="mdc-drawer__header">
+            <h3 class="mdc-drawer__title">Admin</h3>
+            <h6 class="mdc-drawer__subtitle" id="userEmailDisplay"></h6>
           </div>
-          <!-- Sticky Footer -->
-          <footer class="sticky-footer">
-            <div class="container my-auto">
-              <div class="copyright text-center my-auto">
-                <span>Copyright © DSC FUTA 2018</span>
+          <div class="mdc-drawer__content">
+            <nav class="mdc-list" data-mdc-auto-init="MDCList">
+              <a class="mdc-list-item" href="./">
+                <i class="material-icons mdc-list-item__graphic" aria-hidden="true">dashboard</i>
+                <span class="mdc-list-item__text">Dashboard</span>
+              </a>
+              <a class="mdc-list-item" href="events.html">
+                <i class="material-icons mdc-list-item__graphic" aria-hidden="true">event</i>
+                <span class="mdc-list-item__text">Events</span>
+              </a>
+              <a class="mdc-list-item" href="projects.html">
+                <i class="material-icons mdc-list-item__graphic" aria-hidden="true">code</i>
+                <span class="mdc-list-item__text">Projects</span>
+              </a>
+              <a class="mdc-list-item mdc-list-item--activated" href="instructor.html" aria-selected="true">
+                <i class="material-icons mdc-list-item__graphic" aria-hidden="true">account_circle</i>
+                <span class="mdc-list-item__text">Instructors</span>
+              </a>
+              <a class="mdc-list-item" href="tutorials.html">
+                <i class="material-icons mdc-list-item__graphic" aria-hidden="true">book</i>
+                <span class="mdc-list-item__text">Materials</span>
+              </a>
+              <a class="mdc-list-item" href="onboarding.html">
+                <i class="material-icons mdc-list-item__graphic" aria-hidden="true">supervisor_account</i>
+                <span class="mdc-list-item__text">Onboarding</span>
+              </a>
+            </nav>
+          </div>
+        </aside>
+        <div id="content-wrapper">
+          <div class="container-fluid">
+            <!-- Breadcrumbs-->
+            <ol class="breadcrumb">
+              <li class="breadcrumb-item"><a href="#">Dashboard</a></li>
+              <li class="breadcrumb-item active">Instructors</li>
+            </ol>
+  
+            <!-- dashboard card -->
+            <div class="card mb-3">
+              <div class="card-header">
+                <i class="fas fa-fw fa-user"></i> Instructor
+                <i class="fas fa-sync fa-spin" id="refreshButton"></i>
+              </div>
+              <div class="card-body">
+                <div
+                  class="alert alert-danger"
+                  id="instructorErrorAlert"
+                  style="display: none"
+                ></div>
+                <table
+                  class="table table-striped"
+                  id="instructorsTable"
+                  style="min-width: 100%"
+                >
+                  <thead>
+                    <tr>
+                      <th>Instructor's Name</th>
+                      <th>Instructor's Bio</th>
+                      <th>Instructor's Role</th>
+                      <th>Instructor's TwitterId</th>
+                      <th>Instructor's GithubId</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </div>
+              <div class="card-footer text-right">
+                <button class="btn btn-primary" id="addButton" disabled>
+                  Add Instructor
+                </button>
               </div>
             </div>
-          </footer>
+            <!-- Sticky Footer -->
+            <footer class="sticky-footer">
+              <div class="container my-auto">
+                <div class="copyright text-center my-auto">
+                  <span>Copyright © DSC FUTA 2018</span>
+                </div>
+              </div>
+            </footer>
+          </div>
+          <!-- /.content-wrapper -->
         </div>
-        <!-- /.content-wrapper -->
       </div>
       <!-- /#wrapper -->
-
-      <!-- Scroll to Top Button-->
-      <a class="scroll-to-top rounded" href="#page-top">
-        <i class="fas fa-angle-up"></i>
-      </a>
-
-      <!-- Logout Modal-->
-      <div
-        class="modal fade"
-        id="logoutModal"
-        tabindex="-1"
-        role="dialog"
-        aria-labelledby="exampleModalLabel"
-        aria-hidden="true"
-      >
-        <div class="modal-dialog" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h5 class="modal-title" id="exampleModalLabel">
-                Ready to Leave?
-              </h5>
-              <button
-                class="close"
-                type="button"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">×</span>
-              </button>
-            </div>
-            <div
-              class="alert alert-danger"
-              style="display: none"
-              id="errorAlert"
-            ></div>
-            <div class="modal-body">Do you want to logout?</div>
-            <div class="modal-footer">
-              <button
-                class="btn btn-secondary"
-                type="button"
-                data-dismiss="modal"
-              >
-                Cancel
-              </button>
-              <button class="btn btn-primary" type="button" id="logoutButton">
-                Logout
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Create/Edit Instructor Modal -->
-      <div
-        class="modal"
-        id="instructorModal"
-        tabindex="-1"
-        role="dialog"
-        aria-labelledby="instructorModalTitle"
-        aria-hidden="true"
-      >
-        <div class="modal-dialog" role="document">
-          <form class="modal-content" id="instructorForm">
-            <div class="modal-header">
-              <h5 class="modal-title" id="instructorModalTitle">
-                <span class="instructorModalModeText">Add</span> Instructor
-              </h5>
-              <button
-                class="close"
-                type="button"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">×</span>
-              </button>
-            </div>
-            <div class="modal-body">
-              <div
-                class="alert alert-danger"
-                id="instructorModalErrorAlert"
-                style="display: none"
-              ></div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <input
-                    class="form-control"
-                    id="instructorName"
-                    placeholder="Instructor's Name"
-                    required
-                  />
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <textarea
-                    class="form-control"
-                    id="instructorBio"
-                    placeholder="Instructor's Bio"
-                    required
-                  ></textarea>
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <input
-                    class="form-control"
-                    type="text"
-                    id="instructorRole"
-                    placeholder="Instructor's Role"
-                    required
-                  />
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-6">
-                  <input
-                    class="form-control"
-                    type="text"
-                    id="instructorTwitterId"
-                    placeholder="Instructor's Twitter Id"
-                    required
-                  />
-                </div>
-                <div class="col-6">
-                  <input
-                    class="form-control"
-                    type="text"
-                    id="instructorGithubId"
-                    placeholder="Instructor's Github Id"
-                    required
-                  />
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12 mb-3">
-                  <input
-                    class="form-control"
-                    type="file"
-                    id="instructorImage"
-                    placeholder="Instructor's Image"
-                    accept="image/*"
-                  />
-                </div>
-                <div class="col-12">
-                  <div
-                    class="progress"
-                    id="imageUploadProgress"
-                    style="display: none; height: 32px;"
-                  >
-                    <div
-                      class="progress-bar"
-                      role="progressbar"
-                      aria-valuenow="0"
-                      aria-valuemin="0"
-                      aria-valuemax="100"
-                    >
-                      0%
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="modal-footer">
-              <button
-                class="btn btn-secondary"
-                type="button"
-                data-dismiss="modal"
-              >
-                Cancel
-              </button>
-              <button
-                class="btn btn-primary"
-                id="projectSubmitButton"
-                type="submit"
-              >
-                <span class="instructorModalModeText">Add</span>
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
     </div>
 
+    <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
     <script src="js/vendors/firebase-app.js"></script>
     <script src="js/vendors/firebase-auth.min.js"></script>
     <script src="js/vendors/firebase-firestore.min.js"></script>
     <script src="js/vendors/firebase-storage.min.js"></script>
     <script src="vendor/jquery/jquery.min.js"></script>
-    <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <!-- <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
     <script src="vendor/jquery-easing/jquery.easing.min.js"></script>
     <script src="vendor/datatables/jquery.dataTables.min.js"></script>
     <script src="vendor/datatables/dataTables.bootstrap4.min.js"></script>
-    <script src="js/admin.min.js"></script>
+    <script src="js/admin.min.js"></script> -->
     <script src="js/firebase.config.js"></script>
     <script src="js/firebase.js"></script>
-    <script src="js/admin/instructor.js"></script>
+    <script src="js/admin/dashboard.js"></script>
+    <script src="js/material.js"></script>
   </body>
 </html>

--- a/tutorials.html
+++ b/tutorials.html
@@ -5,672 +5,238 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="author" content="DSC FUTA" />
-    <meta
-      name="description"
-      content="Developer Student Clubs (DSC)a is a Google Developers program for university students to learn mobile and web development skills."
-    />
-    <meta
-      name="keywords"
-      content="dsc, futa, kelvin kamau,google developers, sub saharan africa, kenya, computer science"
-    />
-    <title>DSC Admin - Events</title>
+    <meta name="description" content="Developer Student Clubs (DSC)a is a Google Developers program for university students to learn mobile and web development skills."/>
+    <meta name="keywords" content="dsc, futa, kelvin kamau,google developers, sub saharan africa, kenya, computer science"/>
+    <title>DSC Admin - Materials</title>
     <link rel="icon" href="images/icon.png" type="image/png" />
+    <!-- Temporarily left here because of the main content -->
     <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet" />
-    <link
-      href="vendor/fontawesome-free/css/all.min.css"
-      rel="stylesheet"
-      type="text/css"
-    />
-    <link
-      href="vendor/datatables/dataTables.bootstrap4.min.css"
-      rel="stylesheet"
-    />
-    <link href="css/admin.css" rel="stylesheet" />
+    <link href="vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css"/>
+    <link href="vendor/datatables/dataTables.bootstrap4.min.css" rel="stylesheet"/>
+    <link href="css/admin.css" rel="stylesheet" /> 
+    <!-- the above are Temporarily left here because of the main content -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+    <link rel="stylesheet" href="css/styles.css">
   </head>
 
-  <body id="page-top">
-    <nav class="navbar navbar-expand navbar-dark bg-dark static-top">
-      <a class="navbar-brand mr-1" href="index.html"
-        ><img href="images/icon.png" />DSC Admin</a
-      >
-
-      <button
-        class="btn btn-link btn-sm text-white order-1 order-sm-0"
-        id="sidebarToggle"
-        href="#"
-      >
-        <i class="fas fa-bars"></i>
-      </button>
-
-      <!-- Navbar Search -->
-      <form
-        class="d-none d-md-inline-block form-inline ml-auto mr-0 mr-md-3 my-2 my-md-0"
-      >
-        <div class="input-group">
-          <input
-            type="text"
-            class="form-control"
-            placeholder=" "
-            aria-label="Search"
-            aria-describedby="basic-addon2"
-          />
-          <div class="input-group-append">
-            <button class="btn btn-primary" type="button">
-              <i class="fas fa-search"></i>
-            </button>
-          </div>
-        </div>
-      </form>
-
-      <!-- Navbar -->
-      <ul class="navbar-nav ml-auto ml-md-0">
-        <li class="nav-item dropdown no-arrow">
-          <a
-            class="nav-link dropdown-toggle"
-            href="#"
-            id="userDropdown"
-            role="button"
-            data-toggle="dropdown"
-            aria-haspopup="true"
-            aria-expanded="false"
-          >
-            <i class="fas fa-user-circle fa-fw"></i>
-          </a>
-          <div
-            class="dropdown-menu dropdown-menu-right"
-            aria-labelledby="userDropdown"
-          >
-            <a
-              class="dropdown-item"
-              href="#"
-              data-toggle="modal"
-              data-target="#logoutModal"
-              >Logout</a
-            >
-            <a class="dropdown-item" href="index.html">Back to homepage</a>
-          </div>
-        </li>
-      </ul>
-    </nav>
+  <body class="mdc-typography">
+    <header class="mdc-top-app-bar mdc-top-app-bar--fixed" data-mdc-auto-init="MDCTopAppBar">
+      <div class="mdc-top-app-bar__row">
+        <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
+          <a href="./" class="material-icons mdc-top-app-bar__navigation-icon">home</a>
+          <span class="mdc-top-app-bar__title">Materials</span>
+        </section>
+        <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
+          <a href="#" id="logoutButton" class="material-icons mdc-top-app-bar__action-item" aria-label="Logout"
+            alt="Logout">exit_to_app</a>
+        </section>
+      </div>
+    </header>
 
     <div id="wrapper">
-      <!-- Sidebar -->
-      <ul class="sidebar navbar-nav">
-        <li class="nav-item">
-          <a class="nav-link" href="index.html">
-            <i class="fas fa-fw fa-tachometer-alt"></i> <span>Dashboard</span>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="instructor.html">
-            <i class="fas fa-fw fa-user-alt"></i> <span>Instructors</span>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="events.html">
-            <i class="fas fa-fw fa-calendar-alt"></i> <span>Events</span>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="projects.html">
-            <i class="fas fa-fw fa-folder"></i> <span>Projects</span>
-          </a>
-        </li>
-        <li class="nav-item active">
-          <a class="nav-link" href="#">
-            <i class="fas fa-fw fa-book"></i> <span>Tutorials</span>
-          </a>
-        </li>
-      </ul>
-
-      <div id="content-wrapper">
-        <div class="container-fluid">
-          <!-- Breadcrumbs-->
-          <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="#">Dashboard</a></li>
-            <li class="breadcrumb-item active">Tutorials</li>
-          </ol>
-
-          <div class="card mb-3">
-            <div class="card-header d-flex align-items-center">
-              <span class="mr-3">Stack:</span>
-              <select id="stackSelect" class="form-control">
-                <option value="web">Web</option>
-                <option value="mobile">Mobile</option>
-                <option value="mlai">Machine Learning / AI</option>
-                <option value="cloud">Cloud</option>
-              </select>
-            </div>
+      <div class="mdc-top-app-bar--fixed-adjust">
+        <aside class="mdc-drawer">
+          <div class="mdc-drawer__header">
+            <h3 class="mdc-drawer__title">Admin</h3>
+            <h6 class="mdc-drawer__subtitle" id="userEmailDisplay"></h6>
           </div>
-
-          <!-- dashboard card -->
-          <div class="card mb-3">
-            <div class="card-header">
-              <i class="fas fa-fw fa-folder"></i> Courses
-              <i class="fas fa-sync fa-spin btn-refresh" data-type="course"></i>
-            </div>
-            <div class="card-body">
-              <div
-                class="alert alert-danger error-alert"
-                data-type="course"
-                style="display: none"
-              ></div>
-              <table
-                class="table table-striped"
-                id="courseTable"
-                style="min-width: 100%"
-              >
-                <thead>
-                  <tr>
-                    <th>Title</th>
-                    <th>Description</th>
-                    <th>Level</th>
-                    <th>Link</th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
-                <tbody></tbody>
-              </table>
-            </div>
-            <div class="card-footer text-right">
-              <button
-                class="btn btn-primary btn-add"
-                data-type="course"
-                disabled
-              >
-                Add Course
-              </button>
-            </div>
+          <div class="mdc-drawer__content">
+            <nav class="mdc-list" data-mdc-auto-init="MDCList">
+              <a class="mdc-list-item" href="./">
+                <i class="material-icons mdc-list-item__graphic" aria-hidden="true">dashboard</i>
+                <span class="mdc-list-item__text">Dashboard</span>
+              </a>
+              <a class="mdc-list-item" href="events.html">
+                <i class="material-icons mdc-list-item__graphic" aria-hidden="true">event</i>
+                <span class="mdc-list-item__text">Events</span>
+              </a>
+              <a class="mdc-list-item" href="projects.html">
+                <i class="material-icons mdc-list-item__graphic" aria-hidden="true">code</i>
+                <span class="mdc-list-item__text">Projects</span>
+              </a>
+              <a class="mdc-list-item" href="instructor.html">
+                <i class="material-icons mdc-list-item__graphic" aria-hidden="true">account_circle</i>
+                <span class="mdc-list-item__text">Instructors</span>
+              </a>
+              <a class="mdc-list-item mdc-list-item--activated" href="tutorials.html" aria-selected="true">
+                <i class="material-icons mdc-list-item__graphic" aria-hidden="true">book</i>
+                <span class="mdc-list-item__text">Materials</span>
+              </a>
+              <a class="mdc-list-item" href="onboarding.html">
+                <i class="material-icons mdc-list-item__graphic" aria-hidden="true">supervisor_account</i>
+                <span class="mdc-list-item__text">Onboarding</span>
+              </a>
+            </nav>
           </div>
-          <div class="card mb-3">
-            <div class="card-header">
-              <i class="fas fa-fw fa-folder"></i> Books
-              <i class="fas fa-sync fa-spin btn-refresh" data-type="book"></i>
-            </div>
-            <div class="card-body">
-              <div
-                class="alert alert-danger error-alert"
-                data-type="book"
-                style="display: none"
-              ></div>
-              <table
-                class="table table-striped"
-                id="bookTable"
-                style="min-width: 100%"
-              >
-                <thead>
-                  <tr>
-                    <th>Title</th>
-                    <th>Author</th>
-                    <th>Description</th>
-                    <th>Level</th>
-                    <th>Link</th>
-                    <th>Availability</th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
-                <tbody></tbody>
-              </table>
-            </div>
-            <div class="card-footer text-right">
-              <button class="btn btn-primary btn-add" data-type="book" disabled>
-                Add Book
-              </button>
-            </div>
-          </div>
-          <div class="card mb-3">
-            <div class="card-header">
-              <i class="fas fa-fw fa-folder"></i> Documentation
-              <i
-                class="fas fa-sync fa-spin btn-refresh"
-                data-type="documentation"
-              ></i>
-            </div>
-            <div class="card-body">
-              <div
-                class="alert alert-danger error-alert"
-                data-type="documentation"
-                style="display: none"
-              ></div>
-              <table
-                class="table table-striped"
-                id="documentationTable"
-                style="min-width: 100%"
-              >
-                <thead>
-                  <tr>
-                    <th>Title</th>
-                    <th>Description</th>
-                    <th>Level</th>
-                    <th>Link</th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
-                <tbody></tbody>
-              </table>
-            </div>
-            <div class="card-footer text-right">
-              <button
-                class="btn btn-primary btn-add"
-                data-type="documentation"
-                disabled
-              >
-                Add Documentation
-              </button>
-            </div>
-          </div>
-
-          <!-- Sticky Footer -->
-          <footer class="sticky-footer">
-            <div class="container my-auto">
-              <div class="copyright text-center my-auto">
-                <span>Copyright © DSC FUTA 2018</span>
+        </aside>
+        <div id="content-wrapper">
+            <div class="container-fluid">
+              <!-- Breadcrumbs-->
+              <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="./">Dashboard</a></li>
+                <li class="breadcrumb-item active">Materials</li>
+              </ol>
+    
+              <div class="card mb-3">
+                <div class="card-header d-flex align-items-center">
+                  <span class="mr-3">Stack:</span>
+                  <select id="stackSelect" class="form-control">
+                    <option value="web">Web</option>
+                    <option value="mobile">Mobile</option>
+                    <option value="mlai">Machine Learning / AI</option>
+                    <option value="cloud">Cloud</option>
+                  </select>
+                </div>
               </div>
+    
+              <!-- dashboard card -->
+              <div class="card mb-3">
+                <div class="card-header">
+                  <i class="fas fa-fw fa-folder"></i> Courses
+                  <i class="fas fa-sync fa-spin btn-refresh" data-type="course"></i>
+                </div>
+                <div class="card-body">
+                  <div
+                    class="alert alert-danger error-alert"
+                    data-type="course"
+                    style="display: none"
+                  ></div>
+                  <table
+                    class="table table-striped"
+                    id="courseTable"
+                    style="min-width: 100%"
+                  >
+                    <thead>
+                      <tr>
+                        <th>Title</th>
+                        <th>Description</th>
+                        <th>Level</th>
+                        <th>Link</th>
+                        <th>Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+                <div class="card-footer text-right">
+                  <button
+                    class="btn btn-primary btn-add"
+                    data-type="course"
+                    disabled
+                  >
+                    Add Course
+                  </button>
+                </div>
+              </div>
+              <div class="card mb-3">
+                <div class="card-header">
+                  <i class="fas fa-fw fa-folder"></i> Books
+                  <i class="fas fa-sync fa-spin btn-refresh" data-type="book"></i>
+                </div>
+                <div class="card-body">
+                  <div
+                    class="alert alert-danger error-alert"
+                    data-type="book"
+                    style="display: none"
+                  ></div>
+                  <table
+                    class="table table-striped"
+                    id="bookTable"
+                    style="min-width: 100%"
+                  >
+                    <thead>
+                      <tr>
+                        <th>Title</th>
+                        <th>Author</th>
+                        <th>Description</th>
+                        <th>Level</th>
+                        <th>Link</th>
+                        <th>Availability</th>
+                        <th>Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+                <div class="card-footer text-right">
+                  <button class="btn btn-primary btn-add" data-type="book" disabled>
+                    Add Book
+                  </button>
+                </div>
+              </div>
+              <div class="card mb-3">
+                <div class="card-header">
+                  <i class="fas fa-fw fa-folder"></i> Documentation
+                  <i
+                    class="fas fa-sync fa-spin btn-refresh"
+                    data-type="documentation"
+                  ></i>
+                </div>
+                <div class="card-body">
+                  <div
+                    class="alert alert-danger error-alert"
+                    data-type="documentation"
+                    style="display: none"
+                  ></div>
+                  <table
+                    class="table table-striped"
+                    id="documentationTable"
+                    style="min-width: 100%"
+                  >
+                    <thead>
+                      <tr>
+                        <th>Title</th>
+                        <th>Description</th>
+                        <th>Level</th>
+                        <th>Link</th>
+                        <th>Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+                <div class="card-footer text-right">
+                  <button
+                    class="btn btn-primary btn-add"
+                    data-type="documentation"
+                    disabled
+                  >
+                    Add Documentation
+                  </button>
+                </div>
+              </div>
+    
+              <!-- Sticky Footer -->
+              <footer class="sticky-footer">
+                <div class="container my-auto">
+                  <div class="copyright text-center my-auto">
+                    <span>Copyright © DSC FUTA 2020</span>
+                  </div>
+                </div>
+              </footer>
             </div>
-          </footer>
+            <!-- /.content-wrapper -->
         </div>
-        <!-- /.content-wrapper -->
       </div>
       <!-- /#wrapper -->
-
-      <!-- Scroll to Top Button-->
-      <a class="scroll-to-top rounded" href="#page-top">
-        <i class="fas fa-angle-up"></i>
-      </a>
-
-      <!-- Logout Modal-->
-      <div
-        class="modal fade"
-        id="logoutModal"
-        tabindex="-1"
-        role="dialog"
-        aria-labelledby="exampleModalLabel"
-        aria-hidden="true"
-      >
-        <div class="modal-dialog" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h5 class="modal-title" id="exampleModalLabel">
-                Ready to Leave?
-              </h5>
-              <button
-                class="close"
-                type="button"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">×</span>
-              </button>
-            </div>
-            <div
-              class="alert alert-danger"
-              style="display: none"
-              id="errorAlert"
-            ></div>
-            <div class="modal-body">Do you want to logout?</div>
-            <div class="modal-footer">
-              <button
-                class="btn btn-secondary"
-                type="button"
-                data-dismiss="modal"
-              >
-                Cancel
-              </button>
-              <button class="btn btn-primary" type="button" id="logoutButton">
-                Logout
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Add/Edit Course Modal -->
-      <div
-        class="modal"
-        id="courseModal"
-        tabindex="-1"
-        role="dialog"
-        aria-labelledby="courseModalTitle"
-        aria-hidden="true"
-      >
-        <div class="modal-dialog" role="document">
-          <form class="modal-content" id="courseForm">
-            <div class="modal-header">
-              <h5 class="modal-title" id="courseModalTitle">
-                <span class="modalModeText">Add</span> Course
-              </h5>
-              <button
-                class="close"
-                type="button"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">×</span>
-              </button>
-            </div>
-            <div class="modal-body">
-              <div
-                class="alert alert-danger error-alert"
-                id="courseModalErrorAlert"
-                style="display: none"
-              ></div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <input
-                    class="form-control"
-                    id="courseTitle"
-                    placeholder="Course Title"
-                    required
-                  />
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <textarea
-                    class="form-control"
-                    id="courseDescription"
-                    placeholder="Course Description"
-                    required
-                  ></textarea>
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <select
-                    name="courseLevel"
-                    id="courseLevel"
-                    class="form-control"
-                    required
-                  >
-                    <option value="beginner">Beginner</option>
-                    <option value="intermediate">Intermediate</option>
-                    <option value="expert">Expert</option>
-                  </select>
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <input
-                    class="form-control"
-                    id="courseLink"
-                    placeholder="Course Link"
-                    required
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="modal-footer">
-              <button
-                class="btn btn-secondary"
-                type="button"
-                data-dismiss="modal"
-              >
-                Cancel
-              </button>
-              <button
-                class="btn btn-primary btn-submit"
-                data-type="course"
-                type="submit"
-              >
-                <span class="modalModeText">Add</span>
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
-      <!-- Add/Edit Documentation Modal -->
-      <div
-        class="modal"
-        id="documentationModal"
-        tabindex="-1"
-        role="dialog"
-        aria-labelledby="documentationModalTitle"
-        aria-hidden="true"
-      >
-        <div class="modal-dialog" role="document">
-          <form class="modal-content" id="documentationForm">
-            <div class="modal-header">
-              <h5 class="modal-title" id="documentationModalTitle">
-                <span class="modalModeText">Add</span> Course
-              </h5>
-              <button
-                class="close"
-                type="button"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">×</span>
-              </button>
-            </div>
-            <div class="modal-body">
-              <div
-                class="alert alert-danger error-alert"
-                id="documentationModalErrorAlert"
-                style="display: none"
-              ></div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <input
-                    class="form-control"
-                    id="documentationTitle"
-                    placeholder="Documentation Title"
-                    required
-                  />
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <textarea
-                    class="form-control"
-                    id="documentationDescription"
-                    placeholder="Documentation Description"
-                    required
-                  ></textarea>
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <select
-                    name="documentationLevel"
-                    id="documentationLevel"
-                    class="form-control"
-                    required
-                  >
-                    <option value="beginner">Beginner</option>
-                    <option value="intermediate">Intermediate</option>
-                    <option value="expert">Expert</option>
-                  </select>
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <input
-                    class="form-control"
-                    id="documentationLink"
-                    placeholder="Documentation Link"
-                    required
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="modal-footer">
-              <button
-                class="btn btn-secondary"
-                type="button"
-                data-dismiss="modal"
-              >
-                Cancel
-              </button>
-              <button
-                class="btn btn-primary btn-submit"
-                data-type="documentation"
-                type="submit"
-              >
-                <span class="modalModeText">Add</span>
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
-      <!-- Add/Edit Book Modal -->
-      <div
-        class="modal"
-        id="bookModal"
-        tabindex="-1"
-        role="dialog"
-        aria-labelledby="bookModalTitle"
-        aria-hidden="true"
-      >
-        <div class="modal-dialog" role="document">
-          <form class="modal-content" id="bookForm">
-            <div class="modal-header">
-              <h5 class="modal-title" id="bookModalTitle">
-                <span class="modalModeText">Add</span> Book
-              </h5>
-              <button
-                class="close"
-                type="button"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">×</span>
-              </button>
-            </div>
-            <div class="modal-body">
-              <div
-                class="alert alert-danger error-alert"
-                id="bookModalErrorAlert"
-                style="display: none"
-              ></div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <input
-                    class="form-control"
-                    id="bookTitle"
-                    placeholder="Book Title"
-                    required
-                  />
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <input
-                    class="form-control"
-                    id="bookAuthor"
-                    placeholder="Book Author"
-                    required
-                  />
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <textarea
-                    class="form-control"
-                    id="bookDescription"
-                    placeholder="Book Description"
-                    required
-                  ></textarea>
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <select
-                    name="bookLevel"
-                    id="bookLevel"
-                    class="form-control"
-                    required
-                  >
-                    <option value="beginner">Beginner</option>
-                    <option value="intermediate">Intermediate</option>
-                    <option value="expert">Expert</option>
-                  </select>
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12"><p class="form-text">This book is:</p></div>
-                <div class="col-12">
-                  <div class="form-check">
-                    <input
-                      class="form-check-input"
-                      type="checkbox"
-                      value="print"
-                      name="bookAvailability"
-                      id="bookAvailabilityPrint"
-                    />
-                    <label class="form-check-label" for="bookAvailabilityPrint">
-                      Available in printed form
-                    </label>
-                  </div>
-                  <div class="form-check">
-                    <input
-                      type="checkbox"
-                      class="form-check-input"
-                      value="web"
-                      name="bookAvailability"
-                      id="bookAvailabilityWeb"
-                    />
-                    <label for="bookAvailabilityWeb" class="form-check-label">
-                      Available to read online
-                    </label>
-                  </div>
-                  <div class="form-check">
-                    <input
-                      type="checkbox"
-                      name="bookAvailability"
-                      id="bookAvailabilityEbook"
-                      class="form-check-input"
-                      value="ebook"
-                    />
-                    <label for="bookAvailabilityEbook" class="form-check-label">
-                      Available as an EBook
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-12">
-                  <input
-                    class="form-control"
-                    id="bookLink"
-                    placeholder="Book Link"
-                    required
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="modal-footer">
-              <button
-                class="btn btn-secondary"
-                type="button"
-                data-dismiss="modal"
-              >
-                Cancel
-              </button>
-              <button
-                class="btn btn-primary btn-submit"
-                data-type="book"
-                type="submit"
-              >
-                <span class="modalModeText">Add</span>
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
     </div>
 
+    <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
     <script src="js/vendors/firebase-app.js"></script>
     <script src="js/vendors/firebase-auth.min.js"></script>
     <script src="js/vendors/firebase-firestore.min.js"></script>
     <script src="js/vendors/firebase-storage.min.js"></script>
     <script src="vendor/jquery/jquery.min.js"></script>
-    <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <!-- <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
     <script src="vendor/jquery-easing/jquery.easing.min.js"></script>
     <script src="vendor/datatables/jquery.dataTables.min.js"></script>
     <script src="vendor/datatables/dataTables.bootstrap4.min.js"></script>
-    <script src="js/admin.min.js"></script>
+    <script src="js/admin.min.js"></script> -->
     <script src="js/firebase.config.js"></script>
     <script src="js/firebase.js"></script>
-    <script src="js/admin/tutorials.js"></script>
+    <script src="js/admin/dashboard.js"></script>
+    <script src="js/material.js"></script>
   </body>
 </html>


### PR DESCRIPTION
I changed the navbars and sidebars to material design, replicating the designs on the other completed pages:

![Screenshot_2020-05-09 DSC Admin - Instructors(1)](https://user-images.githubusercontent.com/46830860/81475994-4c415d80-9207-11ea-8b9e-f9a9741ff8db.png)

this was what it looked like before and the below is it's present look
![Screenshot_2020-05-09 DSC Admin - Instructors](https://user-images.githubusercontent.com/46830860/81476026-7e52bf80-9207-11ea-8642-af2e3829963f.png)

